### PR TITLE
Fix CDK => SDK typo in how it works

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -18,7 +18,7 @@ You could split **EventBridge Atlas** into these parts.
 
 When you start the application it will require access to your AWS account (.env file).
 
-The `aws-cdk` is used to fetch:
+The `aws-sdk` is used to fetch:
 
 - Your schemas
 - Information about your Registry and Eventbus


### PR DESCRIPTION
I was a bit surprised in reading that EventBridge atlas uses AWS CDK to fetch the schema, but it turns out it's just AWS SDK.
